### PR TITLE
Fix python bug in example.

### DIFF
--- a/pywren.html
+++ b/pywren.html
@@ -258,7 +258,7 @@ the below code).</p>
 
 <span class="k">def</span> <span class="nf">big_flops</span><span class="p">(</span><span class="n">std_dev</span><span class="p">):</span>
     <span class="n">running_sum</span> <span class="o">=</span> <span class="mi">0</span>
-    <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="n">loopcnt</span><span class="p">:</span>
+    <span class="k">for</span> <span class="n">i</span> <span class="ow">in range</span><span class="n">(loopcnt)</span><span class="p">:</span>
         <span class="n">A</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">normal</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="n">std_dev</span><span class="p">,</span> <span class="p">(</span><span class="mi">4096</span><span class="p">,</span> <span class="mi">4096</span><span class="p">))</span>
         <span class="n">B</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">normal</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="n">std_dev</span><span class="p">,</span> <span class="p">(</span><span class="mi">4096</span><span class="p">,</span> <span class="mi">4096</span><span class="p">))</span>
         <span class="n">c</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">dot</span><span class="p">(</span><span class="n">A</span><span class="p">,</span> <span class="n">B</span><span class="p">)</span>


### PR DESCRIPTION
`for i in loopcnt:` causes an error because an `int` isn't iterable 